### PR TITLE
Fix for query string parameter values being split when they contain a comma (,)

### DIFF
--- a/Dust/Core/SignatureBaseStringParts/Parameters/RequestParameters.cs
+++ b/Dust/Core/SignatureBaseStringParts/Parameters/RequestParameters.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Web;
+using Dust.Http;
 
 namespace Dust.Core.SignatureBaseStringParts.Parameters
 {
@@ -24,11 +24,11 @@ namespace Dust.Core.SignatureBaseStringParts.Parameters
 
     	private IEnumerable<Parameter> Map(string key)
         {
-    		return ValueFor(key).Split(',').Select(v => new Parameter(key, v));
+    		return ValuesFor(key).Select(v => new Parameter(key, v));
         }
 
-    	private string ValueFor(string key) {
-    		return _values[key];
+    	private string[] ValuesFor(string key) {
+    		return _values.GetValues(key);
     	}
 
     	#region Implementation of IEnumerable

--- a/Dust/Dust.csproj
+++ b/Dust/Dust.csproj
@@ -88,6 +88,8 @@
     <Compile Include="Core\SignatureBaseStringParts\Parameters\ParameterEncoding.cs" />
     <Compile Include="Core\SignatureBaseStringParts\Verb\VerbPart.cs" />
     <Compile Include="Http\AuthorizationHeader.cs" />
+    <Compile Include="Http\HttpEncoder.cs" />
+    <Compile Include="Http\HttpUtility.cs" />
     <Compile Include="RsaSha1.cs" />
     <Compile Include="TokenKey.cs" />
     <Compile Include="Lang\ObjectExtensions.cs" />

--- a/Dust/Http/HttpEncoder.cs
+++ b/Dust/Http/HttpEncoder.cs
@@ -1,0 +1,691 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Dust.Http
+{
+    //
+    // Authors:
+    //   Patrik Torstensson (Patrik.Torstensson@labs2.com)
+    //   Wictor Wilén (decode/encode functions) (wictor@ibizkit.se)
+    //   Tim Coleman (tim@timcoleman.com)
+    //   Gonzalo Paniagua Javier (gonzalo@ximian.com)
+
+    //   Marek Habersack <mhabersack@novell.com>
+    //
+    // (C) 2005-2010 Novell, Inc (http://novell.com/)
+    //
+
+    //
+    // Permission is hereby granted, free of charge, to any person obtaining
+    // a copy of this software and associated documentation files (the
+    // "Software"), to deal in the Software without restriction, including
+    // without limitation the rights to use, copy, modify, merge, publish,
+    // distribute, sublicense, and/or sell copies of the Software, and to
+    // permit persons to whom the Software is furnished to do so, subject to
+    // the following conditions:
+    // 
+    // The above copyright notice and this permission notice shall be
+    // included in all copies or substantial portions of the Software.
+    // 
+    // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    //
+    internal static class HttpEncoder
+    {
+        static readonly char[] HexChars = "0123456789abcdef".ToCharArray();
+        static readonly object EntitiesLock = new object();
+        static SortedDictionary<string, char> _entities;
+        
+        private static IDictionary<string, char> Entities
+        {
+            get
+            {
+                lock (EntitiesLock)
+                {
+                    if (_entities == null)
+                        InitEntities();
+
+                    return _entities;
+                }
+            }
+        }
+
+        private static void InitEntities()
+        {
+            // Build the hash table of HTML entity references.  This list comes
+            // from the HTML 4.01 W3C recommendation.
+            _entities = new SortedDictionary<string, char>(StringComparer.Ordinal)
+            {
+                {"nbsp", '\u00A0'},
+                {"iexcl", '\u00A1'},
+                {"cent", '\u00A2'},
+                {"pound", '\u00A3'},
+                {"curren", '\u00A4'},
+                {"yen", '\u00A5'},
+                {"brvbar", '\u00A6'},
+                {"sect", '\u00A7'},
+                {"uml", '\u00A8'},
+                {"copy", '\u00A9'},
+                {"ordf", '\u00AA'},
+                {"laquo", '\u00AB'},
+                {"not", '\u00AC'},
+                {"shy", '\u00AD'},
+                {"reg", '\u00AE'},
+                {"macr", '\u00AF'},
+                {"deg", '\u00B0'},
+                {"plusmn", '\u00B1'},
+                {"sup2", '\u00B2'},
+                {"sup3", '\u00B3'},
+                {"acute", '\u00B4'},
+                {"micro", '\u00B5'},
+                {"para", '\u00B6'},
+                {"middot", '\u00B7'},
+                {"cedil", '\u00B8'},
+                {"sup1", '\u00B9'},
+                {"ordm", '\u00BA'},
+                {"raquo", '\u00BB'},
+                {"frac14", '\u00BC'},
+                {"frac12", '\u00BD'},
+                {"frac34", '\u00BE'},
+                {"iquest", '\u00BF'},
+                {"Agrave", '\u00C0'},
+                {"Aacute", '\u00C1'},
+                {"Acirc", '\u00C2'},
+                {"Atilde", '\u00C3'},
+                {"Auml", '\u00C4'},
+                {"Aring", '\u00C5'},
+                {"AElig", '\u00C6'},
+                {"Ccedil", '\u00C7'},
+                {"Egrave", '\u00C8'},
+                {"Eacute", '\u00C9'},
+                {"Ecirc", '\u00CA'},
+                {"Euml", '\u00CB'},
+                {"Igrave", '\u00CC'},
+                {"Iacute", '\u00CD'},
+                {"Icirc", '\u00CE'},
+                {"Iuml", '\u00CF'},
+                {"ETH", '\u00D0'},
+                {"Ntilde", '\u00D1'},
+                {"Ograve", '\u00D2'},
+                {"Oacute", '\u00D3'},
+                {"Ocirc", '\u00D4'},
+                {"Otilde", '\u00D5'},
+                {"Ouml", '\u00D6'},
+                {"times", '\u00D7'},
+                {"Oslash", '\u00D8'},
+                {"Ugrave", '\u00D9'},
+                {"Uacute", '\u00DA'},
+                {"Ucirc", '\u00DB'},
+                {"Uuml", '\u00DC'},
+                {"Yacute", '\u00DD'},
+                {"THORN", '\u00DE'},
+                {"szlig", '\u00DF'},
+                {"agrave", '\u00E0'},
+                {"aacute", '\u00E1'},
+                {"acirc", '\u00E2'},
+                {"atilde", '\u00E3'},
+                {"auml", '\u00E4'},
+                {"aring", '\u00E5'},
+                {"aelig", '\u00E6'},
+                {"ccedil", '\u00E7'},
+                {"egrave", '\u00E8'},
+                {"eacute", '\u00E9'},
+                {"ecirc", '\u00EA'},
+                {"euml", '\u00EB'},
+                {"igrave", '\u00EC'},
+                {"iacute", '\u00ED'},
+                {"icirc", '\u00EE'},
+                {"iuml", '\u00EF'},
+                {"eth", '\u00F0'},
+                {"ntilde", '\u00F1'},
+                {"ograve", '\u00F2'},
+                {"oacute", '\u00F3'},
+                {"ocirc", '\u00F4'},
+                {"otilde", '\u00F5'},
+                {"ouml", '\u00F6'},
+                {"divide", '\u00F7'},
+                {"oslash", '\u00F8'},
+                {"ugrave", '\u00F9'},
+                {"uacute", '\u00FA'},
+                {"ucirc", '\u00FB'},
+                {"uuml", '\u00FC'},
+                {"yacute", '\u00FD'},
+                {"thorn", '\u00FE'},
+                {"yuml", '\u00FF'},
+                {"fnof", '\u0192'},
+                {"Alpha", '\u0391'},
+                {"Beta", '\u0392'},
+                {"Gamma", '\u0393'},
+                {"Delta", '\u0394'},
+                {"Epsilon", '\u0395'},
+                {"Zeta", '\u0396'},
+                {"Eta", '\u0397'},
+                {"Theta", '\u0398'},
+                {"Iota", '\u0399'},
+                {"Kappa", '\u039A'},
+                {"Lambda", '\u039B'},
+                {"Mu", '\u039C'},
+                {"Nu", '\u039D'},
+                {"Xi", '\u039E'},
+                {"Omicron", '\u039F'},
+                {"Pi", '\u03A0'},
+                {"Rho", '\u03A1'},
+                {"Sigma", '\u03A3'},
+                {"Tau", '\u03A4'},
+                {"Upsilon", '\u03A5'},
+                {"Phi", '\u03A6'},
+                {"Chi", '\u03A7'},
+                {"Psi", '\u03A8'},
+                {"Omega", '\u03A9'},
+                {"alpha", '\u03B1'},
+                {"beta", '\u03B2'},
+                {"gamma", '\u03B3'},
+                {"delta", '\u03B4'},
+                {"epsilon", '\u03B5'},
+                {"zeta", '\u03B6'},
+                {"eta", '\u03B7'},
+                {"theta", '\u03B8'},
+                {"iota", '\u03B9'},
+                {"kappa", '\u03BA'},
+                {"lambda", '\u03BB'},
+                {"mu", '\u03BC'},
+                {"nu", '\u03BD'},
+                {"xi", '\u03BE'},
+                {"omicron", '\u03BF'},
+                {"pi", '\u03C0'},
+                {"rho", '\u03C1'},
+                {"sigmaf", '\u03C2'},
+                {"sigma", '\u03C3'},
+                {"tau", '\u03C4'},
+                {"upsilon", '\u03C5'},
+                {"phi", '\u03C6'},
+                {"chi", '\u03C7'},
+                {"psi", '\u03C8'},
+                {"omega", '\u03C9'},
+                {"thetasym", '\u03D1'},
+                {"upsih", '\u03D2'},
+                {"piv", '\u03D6'},
+                {"bull", '\u2022'},
+                {"hellip", '\u2026'},
+                {"prime", '\u2032'},
+                {"Prime", '\u2033'},
+                {"oline", '\u203E'},
+                {"frasl", '\u2044'},
+                {"weierp", '\u2118'},
+                {"image", '\u2111'},
+                {"real", '\u211C'},
+                {"trade", '\u2122'},
+                {"alefsym", '\u2135'},
+                {"larr", '\u2190'},
+                {"uarr", '\u2191'},
+                {"rarr", '\u2192'},
+                {"darr", '\u2193'},
+                {"harr", '\u2194'},
+                {"crarr", '\u21B5'},
+                {"lArr", '\u21D0'},
+                {"uArr", '\u21D1'},
+                {"rArr", '\u21D2'},
+                {"dArr", '\u21D3'},
+                {"hArr", '\u21D4'},
+                {"forall", '\u2200'},
+                {"part", '\u2202'},
+                {"exist", '\u2203'},
+                {"empty", '\u2205'},
+                {"nabla", '\u2207'},
+                {"isin", '\u2208'},
+                {"notin", '\u2209'},
+                {"ni", '\u220B'},
+                {"prod", '\u220F'},
+                {"sum", '\u2211'},
+                {"minus", '\u2212'},
+                {"lowast", '\u2217'},
+                {"radic", '\u221A'},
+                {"prop", '\u221D'},
+                {"infin", '\u221E'},
+                {"ang", '\u2220'},
+                {"and", '\u2227'},
+                {"or", '\u2228'},
+                {"cap", '\u2229'},
+                {"cup", '\u222A'},
+                {"int", '\u222B'},
+                {"there4", '\u2234'},
+                {"sim", '\u223C'},
+                {"cong", '\u2245'},
+                {"asymp", '\u2248'},
+                {"ne", '\u2260'},
+                {"equiv", '\u2261'},
+                {"le", '\u2264'},
+                {"ge", '\u2265'},
+                {"sub", '\u2282'},
+                {"sup", '\u2283'},
+                {"nsub", '\u2284'},
+                {"sube", '\u2286'},
+                {"supe", '\u2287'},
+                {"oplus", '\u2295'},
+                {"otimes", '\u2297'},
+                {"perp", '\u22A5'},
+                {"sdot", '\u22C5'},
+                {"lceil", '\u2308'},
+                {"rceil", '\u2309'},
+                {"lfloor", '\u230A'},
+                {"rfloor", '\u230B'},
+                {"lang", '\u2329'},
+                {"rang", '\u232A'},
+                {"loz", '\u25CA'},
+                {"spades", '\u2660'},
+                {"clubs", '\u2663'},
+                {"hearts", '\u2665'},
+                {"diams", '\u2666'},
+                {"quot", '\u0022'},
+                {"amp", '\u0026'},
+                {"lt", '\u003C'},
+                {"gt", '\u003E'},
+                {"OElig", '\u0152'},
+                {"oelig", '\u0153'},
+                {"Scaron", '\u0160'},
+                {"scaron", '\u0161'},
+                {"Yuml", '\u0178'},
+                {"circ", '\u02C6'},
+                {"tilde", '\u02DC'},
+                {"ensp", '\u2002'},
+                {"emsp", '\u2003'},
+                {"thinsp", '\u2009'},
+                {"zwnj", '\u200C'},
+                {"zwj", '\u200D'},
+                {"lrm", '\u200E'},
+                {"rlm", '\u200F'},
+                {"ndash", '\u2013'},
+                {"mdash", '\u2014'},
+                {"lsquo", '\u2018'},
+                {"rsquo", '\u2019'},
+                {"sbquo", '\u201A'},
+                {"ldquo", '\u201C'},
+                {"rdquo", '\u201D'},
+                {"bdquo", '\u201E'},
+                {"dagger", '\u2020'},
+                {"Dagger", '\u2021'},
+                {"permil", '\u2030'},
+                {"lsaquo", '\u2039'},
+                {"rsaquo", '\u203A'},
+                {"euro", '\u20AC'}
+            };
+        }
+
+        public static string UrlPathEncode (string value)
+        {
+            if (String.IsNullOrEmpty (value))
+                return value;
+
+            var result = new MemoryStream ();
+            int length = value.Length;
+            for (int i = 0; i < length; i++)
+                UrlPathEncodeChar (value [i], result);
+
+            return Encoding.ASCII.GetString (result.ToArray ());
+        }
+
+        internal static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count)
+        {
+            if (bytes == null)
+                throw new ArgumentNullException("bytes");
+
+            int blen = bytes.Length;
+            if (blen == 0)
+                return new byte[0];
+
+            if (offset < 0 || offset >= blen)
+                throw new ArgumentOutOfRangeException("offset");
+
+            if (count < 0 || count > blen - offset)
+                throw new ArgumentOutOfRangeException("count");
+
+            var result = new MemoryStream(count);
+            int end = offset + count;
+            for (int i = offset; i < end; i++)
+                UrlEncodeChar((char)bytes[i], result, false);
+
+            return result.ToArray();
+        }
+
+        internal static void UrlEncodeChar(char c, Stream result, bool isUnicode)
+        {
+            if (c > 255)
+            {
+                int idx;
+                int i = c;
+
+                result.WriteByte((byte)'%');
+                result.WriteByte((byte)'u');
+                idx = i >> 12;
+                result.WriteByte((byte)HexChars[idx]);
+                idx = (i >> 8) & 0x0F;
+                result.WriteByte((byte)HexChars[idx]);
+                idx = (i >> 4) & 0x0F;
+                result.WriteByte((byte)HexChars[idx]);
+                idx = i & 0x0F;
+                result.WriteByte((byte)HexChars[idx]);
+                return;
+            }
+
+            if (c > ' ' && NotEncoded(c))
+            {
+                result.WriteByte((byte)c);
+                return;
+            }
+            if (c == ' ')
+            {
+                result.WriteByte((byte)'+');
+                return;
+            }
+            if ((c < '0') ||
+                (c < 'A' && c > '9') ||
+                (c > 'Z' && c < 'a') ||
+                (c > 'z'))
+            {
+                if (isUnicode && c > 127)
+                {
+                    result.WriteByte((byte)'%');
+                    result.WriteByte((byte)'u');
+                    result.WriteByte((byte)'0');
+                    result.WriteByte((byte)'0');
+                }
+                else
+                    result.WriteByte((byte)'%');
+
+                int idx = (c) >> 4;
+                result.WriteByte((byte)HexChars[idx]);
+                idx = (c) & 0x0F;
+                result.WriteByte((byte)HexChars[idx]);
+            }
+            else
+                result.WriteByte((byte)c);
+        }
+
+        internal static bool NotEncoded(char c)
+        {
+            return (c == '!' || c == '(' || c == ')' || c == '*' || c == '-' || c == '.' || c == '_' || c == '\'');
+        }
+
+        internal static void UrlPathEncodeChar(char c, Stream result)
+        {
+            if (c < 33 || c > 126)
+            {
+                byte[] bIn = Encoding.UTF8.GetBytes(c.ToString());
+                for (int i = 0; i < bIn.Length; i++)
+                {
+                    result.WriteByte((byte)'%');
+                    int idx = (bIn[i]) >> 4;
+                    result.WriteByte((byte)HexChars[idx]);
+                    idx = (bIn[i]) & 0x0F;
+                    result.WriteByte((byte)HexChars[idx]);
+                }
+            }
+            else if (c == ' ')
+            {
+                result.WriteByte((byte)'%');
+                result.WriteByte((byte)'2');
+                result.WriteByte((byte)'0');
+            }
+            else
+                result.WriteByte((byte)c);
+        }
+
+        public static void HtmlDecode(string value, TextWriter output)
+        {
+            if (output == null)
+                throw new ArgumentNullException("output");
+
+            output.Write(HtmlDecode(value));
+        }
+
+        public static string HtmlDecode(string s)
+        {
+            if (s == null)
+                return null;
+
+            if (s.Length == 0)
+                return String.Empty;
+
+            if (s.IndexOf('&') == -1)
+                return s;
+            
+            var rawEntity = new StringBuilder();
+            var entity = new StringBuilder();
+            var output = new StringBuilder();
+            int len = s.Length;
+            // 0 -> nothing,
+            // 1 -> right after '&'
+            // 2 -> between '&' and ';' but no '#'
+            // 3 -> '#' found after '&' and getting numbers
+            int state = 0;
+            int number = 0;
+            bool is_hex_value = false;
+            bool have_trailing_digits = false;
+
+            for (int i = 0; i < len; i++)
+            {
+                char c = s[i];
+                if (state == 0)
+                {
+                    if (c == '&')
+                    {
+                        entity.Append(c);
+                        rawEntity.Append(c);
+                        state = 1;
+                    }
+                    else
+                    {
+                        output.Append(c);
+                    }
+                    continue;
+                }
+
+                if (c == '&')
+                {
+                    state = 1;
+                    if (have_trailing_digits)
+                    {
+                        entity.Append(number.ToString(CultureInfo.InvariantCulture));
+                        have_trailing_digits = false;
+                    }
+
+                    output.Append(entity);
+                    entity.Length = 0;
+                    entity.Append('&');
+                    continue;
+                }
+
+                if (state == 1)
+                {
+                    if (c == ';')
+                    {
+                        state = 0;
+                        output.Append(entity);
+                        output.Append(c);
+                        entity.Length = 0;
+                    }
+                    else
+                    {
+                        number = 0;
+                        is_hex_value = false;
+                        if (c != '#')
+                        {
+                            state = 2;
+                        }
+                        else
+                        {
+                            state = 3;
+                        }
+                        entity.Append(c);
+                        rawEntity.Append(c);
+                    }
+                }
+                else if (state == 2)
+                {
+                    entity.Append(c);
+                    if (c == ';')
+                    {
+                        string key = entity.ToString();
+                        if (key.Length > 1 && Entities.ContainsKey(key.Substring(1, key.Length - 2)))
+                            key = Entities[key.Substring(1, key.Length - 2)].ToString();
+
+                        output.Append(key);
+                        state = 0;
+                        entity.Length = 0;
+                        rawEntity.Length = 0;
+                    }
+                }
+                else if (state == 3)
+                {
+                    if (c == ';')
+                    {
+                        if (number == 0)
+                            output.Append(rawEntity + ";");
+                        else
+                            if (number > 65535)
+                            {
+                                output.Append("&#");
+                                output.Append(number.ToString(CultureInfo.InvariantCulture));
+                                output.Append(";");
+                            }
+                            else
+                            {
+                                output.Append((char)number);
+                            }
+                        state = 0;
+                        entity.Length = 0;
+                        rawEntity.Length = 0;
+                        have_trailing_digits = false;
+                    }
+                    else if (is_hex_value && Uri.IsHexDigit(c))
+                    {
+                        number = number * 16 + Uri.FromHex(c);
+                        have_trailing_digits = true;
+                        rawEntity.Append(c);
+                    }
+                    else if (Char.IsDigit(c))
+                    {
+                        number = number * 10 + (c - '0');
+                        have_trailing_digits = true;
+                        rawEntity.Append(c);
+                    }
+                    else if (number == 0 && (c == 'x' || c == 'X'))
+                    {
+                        is_hex_value = true;
+                        rawEntity.Append(c);
+                    }
+                    else
+                    {
+                        state = 2;
+                        if (have_trailing_digits)
+                        {
+                            entity.Append(number.ToString(CultureInfo.InvariantCulture));
+                            have_trailing_digits = false;
+                        }
+                        entity.Append(c);
+                    }
+                }
+            }
+
+            if (entity.Length > 0)
+            {
+                output.Append(entity);
+            }
+            else if (have_trailing_digits)
+            {
+                output.Append(number.ToString(CultureInfo.InvariantCulture));
+            }
+            return output.ToString();
+        }
+
+        public static string HtmlEncode(string s)
+        {
+            if (s == null)
+                return null;
+
+            if (s.Length == 0)
+                return String.Empty;
+
+            bool needEncode = false;
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (c == '&' || c == '"' || c == '<' || c == '>' || c > 159 || c == '\'')
+                {
+                    needEncode = true;
+                    break;
+                }
+            }
+
+            if (!needEncode)
+                return s;
+
+            var output = new StringBuilder();
+            int len = s.Length;
+
+            for (int i = 0; i < len; i++)
+            {
+                char ch = s[i];
+                switch (ch)
+                {
+                    case '&':
+                        output.Append("&amp;");
+                        break;
+                    case '>':
+                        output.Append("&gt;");
+                        break;
+                    case '<':
+                        output.Append("&lt;");
+                        break;
+                    case '"':
+                        output.Append("&quot;");
+                        break;
+                    case '\'':
+                        output.Append("&#39;");
+                        break;
+                    case '\uff1c':
+                        output.Append("&#65308;");
+                        break;
+
+                    case '\uff1e':
+                        output.Append("&#65310;");
+                        break;
+
+                    default:
+                        if (ch > 159 && ch < 256)
+                        {
+                            output.Append("&#");
+                            output.Append(((int)ch).ToString(CultureInfo.InvariantCulture));
+                            output.Append(";");
+                        }
+                        else
+                            output.Append(ch);
+                        break;
+                }
+            }
+
+            return output.ToString();
+        }
+
+        public static void HtmlEncode(string value, TextWriter output)
+        {
+            if (output == null)
+                throw new ArgumentNullException("output");
+
+            output.Write(HtmlEncode(value));
+        }
+
+        public static byte[] UrlEncode(byte[] bytes, int offset, int count)
+        {
+            return UrlEncodeToBytes(bytes, offset, count);
+        }        
+    }
+}

--- a/Dust/Http/HttpUtility.cs
+++ b/Dust/Http/HttpUtility.cs
@@ -1,0 +1,344 @@
+﻿// 
+// System.Web.HttpUtility
+//
+// Authors:
+//   Patrik Torstensson (Patrik.Torstensson@labs2.com)
+//   Wictor Wilén (decode/encode functions) (wictor@ibizkit.se)
+//   Tim Coleman (tim@timcoleman.com)
+//   Gonzalo Paniagua Javier (gonzalo@ximian.com)
+//
+// Copyright (C) 2005-2010 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Security.Permissions;
+using System.Text;
+using System.Web;
+
+namespace Dust.Http
+{
+	[AspNetHostingPermission (SecurityAction.LinkDemand, Level = AspNetHostingPermissionLevel.Minimal)]
+    internal sealed class HttpUtility
+	{
+		sealed class HttpQsCollection : NameValueCollection
+		{
+			public override string ToString ()
+			{
+				int count = Count;
+				if (count == 0)
+					return "";
+				var sb = new StringBuilder ();
+				string [] keys = AllKeys;
+				for (int i = 0; i < count; i++) {
+					sb.AppendFormat ("{0}={1}&", keys [i], this [keys [i]]);
+				}
+				if (sb.Length > 0)
+					sb.Length--;
+				return sb.ToString ();
+			}
+		}
+		
+        public static string UrlDecode (string str)
+        {
+            return UrlDecode(str, Encoding.UTF8);
+        }
+	
+        static void WriteCharBytes(IList buf, char ch, Encoding e)
+        {
+            if (ch > 255)
+            {
+                foreach (byte b in e.GetBytes(new char[] { ch }))
+                    buf.Add(b);
+            }
+            else
+                buf.Add((byte)ch);
+        }
+
+        public static string UrlDecode(string s, Encoding e)
+        {
+            if (null == s)
+                return null;
+
+            if (s.IndexOf('%') == -1 && s.IndexOf('+') == -1)
+                return s;
+
+            if (e == null)
+                e = Encoding.UTF8;
+
+            long len = s.Length;
+            var bytes = new List<byte>();
+
+            for (int i = 0; i < len; i++)
+            {
+                char ch = s[i];
+                if (ch == '%' && i + 2 < len && s[i + 1] != '%')
+                {
+                    int xchar;
+                    if (s[i + 1] == 'u' && i + 5 < len)
+                    {
+                        // unicode hex sequence
+                        xchar = GetChar(s, i + 2, 4);
+                        if (xchar != -1)
+                        {
+                            WriteCharBytes(bytes, (char)xchar, e);
+                            i += 5;
+                        }
+                        else
+                            WriteCharBytes(bytes, '%', e);
+                    }
+                    else if ((xchar = GetChar(s, i + 1, 2)) != -1)
+                    {
+                        WriteCharBytes(bytes, (char)xchar, e);
+                        i += 2;
+                    }
+                    else
+                    {
+                        WriteCharBytes(bytes, '%', e);
+                    }
+                    continue;
+                }
+
+                if (ch == '+')
+                    WriteCharBytes(bytes, ' ', e);
+                else
+                    WriteCharBytes(bytes, ch, e);
+            }
+
+            byte[] buf = bytes.ToArray();
+            bytes = null;
+            return e.GetString(buf);
+
+        }
+	
+        static int GetInt(byte b)
+        {
+            var c = (char)b;
+            if (c >= '0' && c <= '9')
+                return c - '0';
+
+            if (c >= 'a' && c <= 'f')
+                return c - 'a' + 10;
+
+            if (c >= 'A' && c <= 'F')
+                return c - 'A' + 10;
+
+            return -1;
+        }
+
+        static int GetChar(string str, int offset, int length)
+        {
+            int val = 0;
+            int end = length + offset;
+            for (int i = offset; i < end; i++)
+            {
+                char c = str[i];
+                if (c > 127)
+                    return -1;
+
+                int current = GetInt((byte)c);
+                if (current == -1)
+                    return -1;
+                val = (val << 4) + current;
+            }
+
+            return val;
+        }
+		
+        public static string HtmlDecode (string s) 
+        {
+            if (s == null)
+                return null;
+
+            using (var sw = new StringWriter())
+            {
+                HttpEncoder.HtmlDecode(s, sw);
+                return sw.ToString();
+            }
+        }
+
+        public static string UrlEncode(string str)
+        {
+            return UrlEncode(str, Encoding.UTF8);
+        }
+
+        public static string UrlEncode(string s, Encoding Enc)
+        {
+            if (s == null)
+                return null;
+
+            if (s == String.Empty)
+                return String.Empty;
+
+            bool needEncode = false;
+            int len = s.Length;
+            for (int i = 0; i < len; i++)
+            {
+                char c = s[i];
+                if ((c < '0') || (c < 'A' && c > '9') || (c > 'Z' && c < 'a') || (c > 'z'))
+                {
+                    if (HttpEncoder.NotEncoded(c))
+                        continue;
+
+                    needEncode = true;
+                    break;
+                }
+            }
+
+            if (!needEncode)
+                return s;
+
+            // avoided GetByteCount call
+            byte[] bytes = new byte[Enc.GetMaxByteCount(s.Length)];
+            int realLen = Enc.GetBytes(s, 0, s.Length, bytes, 0);
+            return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, 0, realLen));
+        }
+
+        public static string UrlEncode(byte[] bytes)
+        {
+            if (bytes == null)
+                return null;
+
+            if (bytes.Length == 0)
+                return String.Empty;
+
+            return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, 0, bytes.Length));
+        }
+
+        public static string UrlEncode(byte[] bytes, int offset, int count)
+        {
+            if (bytes == null)
+                return null;
+
+            if (bytes.Length == 0)
+                return String.Empty;
+
+            return Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, offset, count));
+        }
+
+        public static byte[] UrlEncodeToBytes(string str)
+        {
+            return UrlEncodeToBytes(str, Encoding.UTF8);
+        }
+
+        public static byte[] UrlEncodeToBytes(string str, Encoding e)
+        {
+            if (str == null)
+                return null;
+
+            if (str.Length == 0)
+                return new byte[0];
+
+            byte[] bytes = e.GetBytes(str);
+            return UrlEncodeToBytes(bytes, 0, bytes.Length);
+        }
+
+        public static byte[] UrlEncodeToBytes(byte[] bytes)
+        {
+            if (bytes == null)
+                return null;
+
+            if (bytes.Length == 0)
+                return new byte[0];
+
+            return UrlEncodeToBytes(bytes, 0, bytes.Length);
+        }
+
+        public static byte[] UrlEncodeToBytes(byte[] bytes, int offset, int count)
+        {
+            if (bytes == null)
+                return null;
+			return HttpEncoder.UrlEncode (bytes, offset, count);
+        }
+	
+		public static NameValueCollection ParseQueryString (string query)
+		{
+			return ParseQueryString (query, Encoding.UTF8);
+		}
+
+		public static NameValueCollection ParseQueryString (string query, Encoding encoding)
+		{
+			if (query == null)
+				throw new ArgumentNullException ("query");
+			if (encoding == null)
+				throw new ArgumentNullException ("encoding");
+			if (query.Length == 0 || (query.Length == 1 && query[0] == '?'))
+				return new HttpQsCollection ();
+			if (query[0] == '?')
+				query = query.Substring (1);
+				
+			NameValueCollection result = new HttpQsCollection ();
+			ParseQueryString (query, encoding, result);
+			return result;
+		}
+
+		public static void ParseQueryString (string query, Encoding encoding, NameValueCollection result)
+		{
+			if (query.Length == 0)
+				return;
+
+			string decoded = HtmlDecode (query);
+			int decodedLength = decoded.Length;
+			int namePos = 0;
+			bool first = true;
+			while (namePos <= decodedLength) {
+				int valuePos = -1, valueEnd = -1;
+				for (int q = namePos; q < decodedLength; q++) {
+					if (valuePos == -1 && decoded [q] == '=') {
+						valuePos = q + 1;
+					} else if (decoded [q] == '&') {
+						valueEnd = q;
+						break;
+					}
+				}
+
+				if (first) {
+					first = false;
+					if (decoded [namePos] == '?')
+						namePos++;
+				}
+				
+				string name;
+				if (valuePos == -1) {
+					name = null;
+					valuePos = namePos;
+				} else {
+					name = UrlDecode (decoded.Substring (namePos, valuePos - namePos - 1), encoding);
+				}
+				if (valueEnd < 0) {
+					namePos = -1;
+					valueEnd = decoded.Length;
+				} else {
+					namePos = valueEnd + 1;
+				}
+				string value = UrlDecode (decoded.Substring (valuePos, valueEnd - valuePos), encoding);
+
+				result.Add (name, value);
+				if (namePos == -1)
+					break;
+			}
+		}		
+	}    
+}


### PR DESCRIPTION
This fix is needed to resolve an issue with query string parameters that have one or more commas (,) in their value being split due to the assumption that the .Net framework HttpUtility.ParseQueryString method has joined multiple values with the same parameter name.

For example, the query string "?where=TaxNumber.Replace(" ","") == "1234"&page=1" is split into the following parameters:

"where"="TaxNumber.Replace(" ""
"where"=""") == "1234"
"page"="1"

But it should really be as follows:

"where"="TaxNumber.Replace(" ","") == "1234""
"page"="1"
