### PR TITLE
Change the sort ordering to be Ordinal rather than Invariant culture as per OAuth spec

### DIFF
--- a/Dust/Core/SignatureBaseStringParts/Parameters/Parameters.cs
+++ b/Dust/Core/SignatureBaseStringParts/Parameters/Parameters.cs
@@ -51,7 +51,7 @@ namespace Dust.Core.SignatureBaseStringParts.Parameters {
 			}
 
 			private int CompareCore(string x, string y) {
-				return string.Compare(x, y, StringComparison.InvariantCulture);
+				return string.Compare(x, y, StringComparison.Ordinal);
 			}
 		}
 	}


### PR DESCRIPTION
Hey @ben-biddington , 

While updating the Xero-Net wrapper for LinkedTransaction filtering, I was getting invalid signature responses from the Xero API. The problem was that the API and Dust sort the parameters differently which results in the signiture being different. I checked the OAuth spec (http://oauth.net/core/1.0a/#anchor13) which says the parameters should be sorted in lexographical byte value order which in C# is ordinal.

We have Dust pulled into Xero-Net so we have made the change in there but also wanted to make a PR here for future users.
